### PR TITLE
ci: reduce renovate noise by grouping minor and patch

### DIFF
--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,8 +5,8 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  extends: ["config:base"],
-  configMigration: true,
+  //extends: ["config:base"],
+  //configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",
@@ -48,9 +48,10 @@ module.exports = {
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/.*/"],
+      matchPackageNames: ["**"],
       groupName: "all dependencies",
-      groupSlug: "all"
+      groupSlug: "all",
+      enabled: true
     }
   ],
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -67,10 +67,9 @@ module.exports = {
       matchUpdateTypes: ["minor", "patch"]
     },
     {
-      groupName: "serilog major dependencies",
-      groupSlug: "serilog-major",
-      matchPackagePatterns: [".*serilog.*"],
-      matchUpdateTypes: ["major"]
+      matchPackagePatterns: [".*"],
+      matchUpdateTypes: ["major"],
+      branchPrefix: "upgrade-major/",
     }
   ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -26,8 +26,7 @@ module.exports = {
   updateNotScheduled: false,
   timezone: "Europe/London",
   schedule: [
-    "after 10pm",
-    "before 5am"
+    "anytime"
   ],
 
   // This setting helps handle breaking changes to Renovate bot when its version changes.

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -45,4 +45,13 @@ module.exports = {
   repositories: [
     "SwanseaUniversityMedical/DARE-Control",
   ],
+
+  packageRules: [
+    {
+      matchUpdateTypes: ["minor", "patch"],
+      matchPackagePatterns: [".*"],
+      groupName: "all dependencies",
+      groupSlug: "all"
+    }
+  ],
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -45,12 +45,13 @@ module.exports = {
     "SwanseaUniversityMedical/DARE-Control",
   ],
 
-  branchPrefix: "renovate-deps/",
-
+  branchPrefix: "upgrade/",
+  separateMajorMinor: false,
+  
   packageRules: [
     {
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["**"],
+      //matchUpdateTypes: ["minor", "patch"],
+      matchPackageNames: ["*"],
       groupName: "all dependencies",
       groupSlug: "all"
     }

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -47,8 +47,8 @@ module.exports = {
 
   branchPrefix: "upgrade/",
   //separateMajorMinor: false,
-  groupName: "all dependencies",
-  groupSlug: "all",
+  //groupName: "all dependencies",
+  //groupSlug: "all",
   
   packageRules: [
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -47,15 +47,15 @@ module.exports = {
 
   branchPrefix: "upgrade/",
   //separateMajorMinor: false,
-  //groupName: "all dependencies",
-  //groupSlug: "all",
+  groupName: "all dependencies",
+  groupSlug: "all",
   
-  packageRules: [
-    {
-      //matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["*"],
-      groupName: "all dependencies",
-      groupSlug: "all"
-    }
-  ],
+  // packageRules: [
+  //   {
+  //     //matchUpdateTypes: ["minor", "patch"],
+  //     matchPackageNames: ["*"],
+  //     groupName: "all dependencies",
+  //     groupSlug: "all"
+  //   }
+  // ],
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -26,7 +26,8 @@ module.exports = {
   updateNotScheduled: false,
   timezone: "Europe/London",
   schedule: [
-    "at any time"
+    "after 10pm",
+    "before 5am"
   ],
 
   // This setting helps handle breaking changes to Renovate bot when its version changes.

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,7 +5,7 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  extends: ["config:base"],
+  //extends: ["config:base"], // <- causes weird monorepo groups
   configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,8 +5,8 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  extends: ["config:base"],
-  configMigration: true,
+  //extends: ["config:base"],
+  //configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",
@@ -47,6 +47,8 @@ module.exports = {
 
   branchPrefix: "upgrade/",
   separateMajorMinor: false,
+  groupName: "all dependencies",
+  groupSlug: "all",
   
   packageRules: [
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,7 +5,7 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  extends: ["config:base"],
+  //extends: ["config:base"],
   configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
@@ -49,7 +49,13 @@ module.exports = {
   
   packageRules: [
     {
-      groupName: "all ungrouped non-major dependencies",
+      groupName: "workflows",
+      groupSlug: "workflows",
+      matchPackagePatterns: ["SwanseaUniversityMedical\/workflows"],
+      matchUpdateTypes: ["minor", "patch"]
+    },
+    {
+      groupName: "all non-major dependencies",
       groupSlug: "all-minor-patch",
       matchPackagePatterns: [".*"],
       matchUpdateTypes: ["minor", "patch"]

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -6,7 +6,7 @@ module.exports = {
 
   // Inherit default config options
   //extends: ["config:base"],
-  //configMigration: true,
+  configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -45,6 +45,8 @@ module.exports = {
     "SwanseaUniversityMedical/DARE-Control",
   ],
 
+  branchPrefix: "renovate-deps",
+
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -49,6 +49,12 @@ module.exports = {
   
   packageRules: [
     {
+      groupName: "all non-major dependencies",
+      groupSlug: "all-minor-patch",
+      matchPackagePatterns: [".*"],
+      matchUpdateTypes: ["minor", "patch"]
+    },
+    {
       groupName: "workflows non-major dependencies",
       groupSlug: "workflows-minor-patch",
       matchPackagePatterns: ["SwanseaUniversityMedical\/workflows"],
@@ -58,12 +64,6 @@ module.exports = {
       groupName: "serilog non-major dependencies",
       groupSlug: "serilog-minor-patch",
       matchPackagePatterns: [".*serilog.*"],
-      matchUpdateTypes: ["minor", "patch"]
-    },
-    {
-      groupName: "all non-major dependencies",
-      groupSlug: "all-minor-patch",
-      matchPackagePatterns: [".*"],
       matchUpdateTypes: ["minor", "patch"]
     }
   ]

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,7 +5,7 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  //extends: ["config:base"],
+  extends: ["config:base"],
   configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
@@ -50,8 +50,7 @@ module.exports = {
       matchUpdateTypes: ["minor", "patch"],
       matchPackageNames: ["**"],
       groupName: "all dependencies",
-      groupSlug: "all",
-      enabled: true
+      groupSlug: "all"
     }
   ],
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -51,13 +51,13 @@ module.exports = {
     {
       groupName: "all non-major dependencies",
       groupSlug: "all-minor-patch",
-      matchPackagePatterns: [".*"],
+      matchPackageNames: ["*"],
       matchUpdateTypes: ["minor", "patch"]
     },
     {
       groupName: "workflows non-major dependencies",
       groupSlug: "workflows-minor-patch",
-      matchPackagePatterns: ["SwanseaUniversityMedical\/workflows"],
+      matchPackageNames: ["SwanseaUniversityMedical/workflows"],
       matchUpdateTypes: ["minor", "patch"]
     },
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -2,7 +2,7 @@ module.exports = {
 
   // Uncomment dryRun to test exotic config options without spamming dozens of
   // pull requests onto a repo that you would then need to clean up...
-  dryRun: "full",
+  //dryRun: "full",
 
   // Inherit default config options
   //extends: ["config:base"], // <- causes weird monorepo groups

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -49,7 +49,7 @@ module.exports = {
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],
-      matchPackagePatterns: [".*"],
+      matchPackageNames: ["**"],
       groupName: "all dependencies",
       groupSlug: "all"
     }

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -49,9 +49,15 @@ module.exports = {
   
   packageRules: [
     {
-      groupName: "workflows",
-      groupSlug: "workflows",
+      groupName: "workflows non-major dependencies",
+      groupSlug: "workflows-minor-patch",
       matchPackagePatterns: ["SwanseaUniversityMedical\/workflows"],
+      matchUpdateTypes: ["minor", "patch"]
+    },
+    {
+      groupName: "serilog non-major dependencies",
+      groupSlug: "serilog-minor-patch",
+      matchPackagePatterns: ["serilog"],
       matchUpdateTypes: ["minor", "patch"]
     },
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -57,7 +57,7 @@ module.exports = {
     {
       groupName: "serilog non-major dependencies",
       groupSlug: "serilog-minor-patch",
-      matchPackagePatterns: ["serilog"],
+      matchPackagePatterns: [".*serilog.*"],
       matchUpdateTypes: ["minor", "patch"]
     },
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -45,7 +45,7 @@ module.exports = {
     "SwanseaUniversityMedical/DARE-Control",
   ],
 
-  branchPrefix: "renovate-deps",
+  branchPrefix: "renovate-deps/",
 
   packageRules: [
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,8 +5,8 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  //extends: ["config:base"],
-  //configMigration: true,
+  extends: ["config:base"],
+  configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,8 +5,8 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  extends: ["config:base"],
-  configMigration: true,
+  //extends: ["config:base"],
+  //configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",
@@ -46,13 +46,13 @@ module.exports = {
   ],
 
   branchPrefix: "upgrade/",
-  separateMajorMinor: false,
+  //separateMajorMinor: false,
   groupName: "all dependencies",
   groupSlug: "all",
   
   packageRules: [
     {
-      //matchUpdateTypes: ["minor", "patch"],
+      matchUpdateTypes: ["minor", "patch"],
       matchPackageNames: ["*"],
       groupName: "all dependencies",
       groupSlug: "all"

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -54,7 +54,7 @@ module.exports = {
     {
       groupName: "all non-major dependencies",
       groupSlug: "all-minor-patch",
-      matchPackageNames: ["*"],
+      matchPackagePatterns: [".*"],
       //matchUpdateTypes: ["minor", "patch"]
     }
   ]

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -47,29 +47,15 @@ module.exports = {
 
   branchPrefix: "upgrade/",
   //separateMajorMinor: false,
-  //groupName: "all dependencies",
-  //groupSlug: "all",
-  
-  // packageRules: [
-  //   {
-  //     //matchUpdateTypes: ["minor", "patch"],
-  //     matchPackageNames: ["*"],
-  //     groupName: "all dependencies",
-  //     groupSlug: "all"
-  //   }
-  // ],
+  groupName: "sigh",
+  groupSlug: "sigh",
 
   packageRules: [
     {
       groupName: "all non-major dependencies",
       groupSlug: "all-minor-patch",
-      matchPackageNames: [
-        "*"
-      ],
-      matchUpdateTypes: [
-        "minor",
-        "patch"
-      ]
+      matchPackageNames: ["*"],
+      //matchUpdateTypes: ["minor", "patch"]
     }
   ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -26,7 +26,7 @@ module.exports = {
   updateNotScheduled: false,
   timezone: "Europe/London",
   schedule: [
-    "anytime"
+    "at any time"
   ],
 
   // This setting helps handle breaking changes to Renovate bot when its version changes.

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,8 +5,8 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  //extends: ["config:base"],
-  //configMigration: true,
+  extends: ["config:base"],
+  configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them
   semanticCommits: "enabled",
@@ -46,16 +46,13 @@ module.exports = {
   ],
 
   branchPrefix: "upgrade/",
-  //separateMajorMinor: false,
-  groupName: "sigh",
-  groupSlug: "sigh",
-
+  
   packageRules: [
     {
-      groupName: "all non-major dependencies",
+      groupName: "all ungrouped non-major dependencies",
       groupSlug: "all-minor-patch",
       matchPackagePatterns: [".*"],
-      //matchUpdateTypes: ["minor", "patch"]
+      matchUpdateTypes: ["minor", "patch"]
     }
   ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -46,6 +46,8 @@ module.exports = {
   ],
 
   branchPrefix: "upgrade/",
+
+  ignorePaths: ["charts/**"],
   
   packageRules: [
     {

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -52,7 +52,7 @@ module.exports = {
   
   packageRules: [
     {
-      matchUpdateTypes: ["minor", "patch"],
+      //matchUpdateTypes: ["minor", "patch"],
       matchPackageNames: ["*"],
       groupName: "all dependencies",
       groupSlug: "all"

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -5,7 +5,7 @@ module.exports = {
   dryRun: "full",
 
   // Inherit default config options
-  //extends: ["config:base"],
+  extends: ["config:base"],
   configMigration: true,
 
   // Force use of Conventional Commit messages to avoid Renovate not detecting them

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -65,6 +65,12 @@ module.exports = {
       groupSlug: "serilog-minor-patch",
       matchPackagePatterns: [".*serilog.*"],
       matchUpdateTypes: ["minor", "patch"]
+    },
+    {
+      groupName: "serilog major dependencies",
+      groupSlug: "serilog-major",
+      matchPackagePatterns: [".*serilog.*"],
+      matchUpdateTypes: ["major"]
     }
   ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -2,7 +2,7 @@ module.exports = {
 
   // Uncomment dryRun to test exotic config options without spamming dozens of
   // pull requests onto a repo that you would then need to clean up...
-  //dryRun: "full",
+  dryRun: "full",
 
   // Inherit default config options
   extends: ["config:base"],
@@ -48,7 +48,7 @@ module.exports = {
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["**"],
+      matchPackageNames: ["/.*/"],
       groupName: "all dependencies",
       groupSlug: "all"
     }

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -47,8 +47,8 @@ module.exports = {
 
   branchPrefix: "upgrade/",
   //separateMajorMinor: false,
-  groupName: "all dependencies",
-  groupSlug: "all",
+  //groupName: "all dependencies",
+  //groupSlug: "all",
   
   // packageRules: [
   //   {
@@ -58,4 +58,18 @@ module.exports = {
   //     groupSlug: "all"
   //   }
   // ],
+
+  packageRules: [
+    {
+      groupName: "all non-major dependencies",
+      groupSlug: "all-minor-patch",
+      matchPackageNames: [
+        "*"
+      ],
+      matchUpdateTypes: [
+        "minor",
+        "patch"
+      ]
+    }
+  ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -44,8 +44,6 @@ module.exports = {
   repositories: [
     "SwanseaUniversityMedical/DARE-Control",
   ],
-
-  branchPrefix: "upgrade/",
   
   packageRules: [
     {
@@ -61,15 +59,9 @@ module.exports = {
       matchUpdateTypes: ["minor", "patch"]
     },
     {
-      groupName: "serilog non-major dependencies",
-      groupSlug: "serilog-minor-patch",
-      matchPackagePatterns: [".*serilog.*"],
-      matchUpdateTypes: ["minor", "patch"]
-    },
-    {
       matchPackagePatterns: [".*"],
       matchUpdateTypes: ["major"],
-      branchPrefix: "upgrade-major/",
+      dependencyDashboardApproval: true
     }
   ]
 };

--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -44,6 +44,8 @@ module.exports = {
   repositories: [
     "SwanseaUniversityMedical/DARE-Control",
   ],
+
+  branchPrefix: "upgrade/",
   
   packageRules: [
     {
@@ -59,7 +61,6 @@ module.exports = {
       matchUpdateTypes: ["minor", "patch"]
     },
     {
-      matchPackagePatterns: [".*"],
       matchUpdateTypes: ["major"],
       dependencyDashboardApproval: true
     }

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,4 +22,4 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
           config: '.github/renovate.js'
         env: 
-          LOG_LEVEL: debug
+          LOG_LEVEL: info

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -14,7 +14,7 @@ jobs:
   renovate:
     runs-on:
       labels: [ self-hosted, linux, x64 ]
-      group: heavy
+      group: light
 
     steps:
       - uses: SwanseaUniversityMedical/workflows/.github/actions/renovate@v1.0.0-renovate

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,3 +21,5 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           config: '.github/renovate.js'
+        env: 
+          LOG_LEVEL: debug

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ jobs:
       group: light
 
     steps:
-      - uses: SwanseaUniversityMedical/workflows/.github/actions/renovate@v1.0.0-renovate
+      - uses: SwanseaUniversityMedical/workflows/.github/actions/renovate@renovate/renovatebot-github-action-40.x
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           config: '.github/renovate.js'

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ jobs:
       group: light
 
     steps:
-      - uses: SwanseaUniversityMedical/workflows/.github/actions/renovate@renovate/renovatebot-github-action-40.x
+      - uses: SwanseaUniversityMedical/workflows/.github/actions/renovate@v1.0.1-renovate
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
           config: '.github/renovate.js'


### PR DESCRIPTION
## :construction: Suggest a change

Reduce renovate PR noise by group all minor and patch level updates into a single PR that should be easier to test. 

Changes the renovate branch prefix from `renovate/` to `upgrade/`. This is to avoid renovate seeing all of it's old abandoned PRs from the old settings which breaks the new group rules.