### PR TITLE
refactor: update renovate schedule to not run on weekends

### DIFF
--- a/.github/renovate.js
+++ b/.github/renovate.js
@@ -25,9 +25,9 @@ module.exports = {
   // requests for dependencies unless they override the schedule.
   updateNotScheduled: false,
   timezone: "Europe/London",
+  //after 10pm and before 5am every weekday
   schedule: [
-    "after 10pm",
-    "before 5am"
+    "* 22-23,0-4 * * 1-5"
   ],
 
   // This setting helps handle breaking changes to Renovate bot when its version changes.

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
     types: [renovate]
   schedule:
-    - cron: '0 * * * *'
+    - cron: '59 * * * 1-5'
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## :construction: Suggest a change

Run renovate hourly on weekdays. Only update external dependency PRs between 10pm and 5am on weekdays.