### PR TITLE
feat: inject db credentials

### DIFF
--- a/src/BL/Models/Settings/TreDbCredentials.cs
+++ b/src/BL/Models/Settings/TreDbCredentials.cs
@@ -1,0 +1,12 @@
+namespace BL.Models.Settings;
+
+public class TreDbCredentials
+{
+    public string Username { get; set; } = string.Empty;
+    
+    public string Password { get; set; } = string.Empty;
+    
+    public string Host { get; set; } = string.Empty;
+    
+    public string Database { get; set; } = string.Empty;
+}

--- a/src/TRE-API/Constants/FeatureFlags.cs
+++ b/src/TRE-API/Constants/FeatureFlags.cs
@@ -8,6 +8,6 @@ public static class FeatureFlags
 
     public const string DemoAllInOne = nameof(DemoAllInOne);
     
-    public const string UseDbCredentials = nameof(UseDbCredentials);
+    public const string InjectDbCredentials = nameof(InjectDbCredentials);
 
 }

--- a/src/TRE-API/Constants/FeatureFlags.cs
+++ b/src/TRE-API/Constants/FeatureFlags.cs
@@ -7,4 +7,7 @@ public static class FeatureFlags
     public const string SqlAndNotGraphQl = nameof(SqlAndNotGraphQl);
 
     public const string DemoAllInOne = nameof(DemoAllInOne);
+    
+    public const string UseDbCredentials = nameof(UseDbCredentials);
+
 }

--- a/src/TRE-API/DoAgentWork.cs
+++ b/src/TRE-API/DoAgentWork.cs
@@ -552,11 +552,23 @@ namespace TRE_API
                                         }
                                     }
 
-                                    if (await _features.IsEnabledAsync(FeatureFlags.UseDbCredentials))
+                                    if (await _features.IsEnabledAsync(FeatureFlags.InjectDbCredentials))
                                     {
-                                        // for analysis container
-                                        var connectionString = $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";
-                                        Executor.Command.Add("--Connection=" + connectionString );
+                                        if (Executor.Image.Contains("tre-sqlpg"))
+                                        {
+                                            // inject credentials as a connection string
+                                            var connectionString = $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";
+                                            Executor.Command.Add("--Connection=" + connectionString );
+                                        }
+                                        else
+                                        {
+                                            // inject credentials as env vars
+                                            Executor.Env["Username"] = _AgentSettings.Credentials.Username;
+                                            Executor.Env["Password"] = _AgentSettings.Credentials.Password;
+                                            Executor.Env["Database"] = _AgentSettings.Credentials.Database;
+                                            Executor.Env["Host"] = _AgentSettings.Credentials.Host;
+                                        }
+                                       
                                     }
                                 }
 

--- a/src/TRE-API/DoAgentWork.cs
+++ b/src/TRE-API/DoAgentWork.cs
@@ -551,6 +551,13 @@ namespace TRE_API
                                             Executor.Command.Add("--URL_" + _AgentSettings.URLHasuraToAdd);
                                         }
                                     }
+
+                                    if (await _features.IsEnabledAsync(FeatureFlags.UseDbCredentials))
+                                    {
+                                        // for analysis container
+                                        var connectionString = $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";
+                                        Executor.Command.Add("--Connection=" + connectionString );
+                                    }
                                 }
 
                                 _dbContext.TokensToExpire.Add(new TokenToExpire()

--- a/src/TRE-API/DoAgentWork.cs
+++ b/src/TRE-API/DoAgentWork.cs
@@ -554,7 +554,7 @@ namespace TRE_API
 
                                     if (await _features.IsEnabledAsync(FeatureFlags.InjectDbCredentials))
                                     {
-                                        if (Executor.Image.Contains("tre-sqlpg"))
+                                        if (Executor.Image.Contains("tre-sqlpg") || Executor.Image.Contains(_AgentSettings.ImageNameToAddToToken))
                                         {
                                             // inject credentials as a connection string
                                             var connectionString = $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";

--- a/src/TRE-API/DoAgentWork.cs
+++ b/src/TRE-API/DoAgentWork.cs
@@ -554,11 +554,13 @@ namespace TRE_API
 
                                     if (await _features.IsEnabledAsync(FeatureFlags.InjectDbCredentials))
                                     {
-                                        if (Executor.Image.Contains("tre-sqlpg") || Executor.Image.Contains(_AgentSettings.ImageNameToAddToToken))
+                                        if (Executor.Image.Contains("tre-sqlpg") ||
+                                            Executor.Image.Contains(_AgentSettings.ImageNameToAddToToken))
                                         {
                                             // inject credentials as a connection string
-                                            var connectionString = $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";
-                                            Executor.Command.Add("--Connection=" + connectionString );
+                                            var connectionString =
+                                                $"Host={_AgentSettings.Credentials.Host};Username={_AgentSettings.Credentials.Username};Password={_AgentSettings.Credentials.Password};Database={_AgentSettings.Credentials.Database}";
+                                            Executor.Command.Add("--Connection=" + connectionString);
                                         }
                                         else
                                         {
@@ -568,6 +570,7 @@ namespace TRE_API
                                             Executor.Env["Database"] = _AgentSettings.Credentials.Database;
                                             Executor.Env["Host"] = _AgentSettings.Credentials.Host;
                                         }
+                                        
                                        
                                     }
                                 }

--- a/src/TRE-API/Models/AgentSettings.cs
+++ b/src/TRE-API/Models/AgentSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace TRE_API.Models
+﻿using BL.Models.Settings;
+
+namespace TRE_API.Models
 {
     public class AgentSettings
     {
@@ -21,5 +23,7 @@
         public string URLTrinoToAdd { get; set; }
 
         public string CATALOG { get; set; }
+        
+        public TreDbCredentials Credentials { get; set; } = new TreDbCredentials();
     }
 }

--- a/src/TRE-API/appsettings.json
+++ b/src/TRE-API/appsettings.json
@@ -151,7 +151,8 @@
   "Features": {
     "GenerateAccounts": false,
     "SqlAndNotGraphQl": true,
-    "DemoAllInOne": false
+    "DemoAllInOne": false,
+    "InjectDbCredentials": true
   },
   "VaultSettings": {
     "BaseUrl": "http://localhost:8200",


### PR DESCRIPTION
## :construction: Suggest a change

- Add FeatureFlag `InjectDbCredentials` for injecting credentials - set default to true
- Create TreDbCredentials and add them as `Credentials` to the AgentSettings
- Inject the credentials as a connection string, if the container image name is the tre sql pg one or one set by the ImageNameToAddToToken option.
- Otherwise inject them as ENV variables
## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
