### PR TITLE
fix: token expiring time on UI

### DIFF
--- a/src/DARE-FrontEnd/Views/Account/NewTokenIssue.cshtml
+++ b/src/DARE-FrontEnd/Views/Account/NewTokenIssue.cshtml
@@ -13,7 +13,7 @@
     <div class="d-flex align-items-center justify-content-between mb-4">
         <div>
             <h2 class="fs-5">Current Access Token</h2>
-            <p class="mb-0">Expires: @ViewBag.TokenExpiryDate</p>
+            <p class="mb-0">Expires: @ViewBag.TokenExpiryDate UTC</p>
         </div>
         <div class="d-flex align-items-center">
             <a tabindex="0" class="copy-btn btn btn-outline-secondary btn-sm me-2" role="button" data-toggle="tooltip" data-trigger="focus" data-placement="top" title="Copied" data-clipboard-target="#api-token">


### PR DESCRIPTION
## :construction: Suggest a change

This PR fixed the expiry time of the API access token on the UI of the Submission Layer:
- Before this PR: The token's expiring time is `currentTime` + `TokenRefreshSeconds` (which is 1h/3600s). The `TokenRefreshSeconds` was presumably set correctly for the `max_age` of the token, but shouldn't be added to the current time to figure out the expiry time of the token. Related ticket: https://ukserp.atlassian.net/browse/TREFX-317
- The expiry time of the token now is figured out by decoding the JWT --> getting the `exp` claim from here, and rendering on the UI. Note: The token can still be valid for 5 minutes after this `exp` time, due to the [`ClockSkew`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.clockskew?view=msal-web-dotnet-latest) property (https://dev.to/marknefedov/dotnet-authentication-clock-skew-ibi)

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
