### PR TITLE
fix: tab indication on TRE UI

### DIFF
--- a/src/DARE-FrontEnd/Views/Shared/_Layout.cshtml
+++ b/src/DARE-FrontEnd/Views/Shared/_Layout.cshtml
@@ -143,7 +143,7 @@
                         <a class="nav-link text-light" href="https://dareuk.org.uk/contact/" target="_blank" rel="noopener">Contact Us</a>
                     </li>
                 </ul>
-                <p class="text-light mt-md-0 mt-5 mb-0">&copy; DARE UK - @UIName.Name 2023. All rights reserved.</p>
+                <p class="text-light mt-md-0 mt-5 mb-0">&copy; DARE UK - @UIName.Name @DateTime.Now.Year. All rights reserved.</p>
             </div>
         </div>
     </footer>

--- a/src/Data-Egress-UI/Views/Shared/_Layout.cshtml
+++ b/src/Data-Egress-UI/Views/Shared/_Layout.cshtml
@@ -115,7 +115,7 @@
 						<a class="nav-link text-light" href="https://dareuk.org.uk/contact/" target="_blank" rel="noopener">Contact Us</a>
 					</li>
 				</ul>
-				<p class="text-light mt-md-0 mt-5 mb-0">&copy;DARE UK - DATA Egress 2023. All rights reserved.</p>
+				<p class="text-light mt-md-0 mt-5 mb-0">&copy;DARE UK - DATA Egress @DateTime.Now.Year. All rights reserved.</p>
 			</div>
 		</div>
 	</footer>

--- a/src/TRE-UI/Views/Approval/GetAllProjects.cshtml
+++ b/src/TRE-UI/Views/Approval/GetAllProjects.cshtml
@@ -3,103 +3,38 @@
 @{
     ViewData["Title"] = "Projects";
     var projectsCount = Model.Count;
+    var showOnlyUnprocessed = ViewBag.ShowOnlyUnprocessed ?? false;
+    var unprocessedProjects = Model.Where(p => p.Decision == Decision.Undecided).ToList();
 }
 
 <div class="container-lg p-4">
     <div class="d-flex align-items-center justify-content-between">
         <h1 class="fs-3 mb-0">Projects</h1>
-
     </div>
-    <ul class="nav nav-underline border-bottom my-4 projects-menu">
+    
+    <ul class="nav nav-underline border-bottom my-4 projects-menu" id="projectTab" role="tablist">
         <li class="nav-item" role="presentation">
-            <a href="@Url.Action("GetAllProjects","Approval", new {  showOnlyUnprocessed = false })" class="nav-link text-dark active">All Projects</a>
+            <a href="#all-projects" class="nav-link text-dark @(!showOnlyUnprocessed ? "active" : "")" id="all-projects-tab" data-bs-toggle="tab" data-bs-target="#all-projects" role="tab" aria-controls="all-projects" aria-selected="@(!showOnlyUnprocessed)">
+                All Projects
+                <span class="badge bg-dark-blue rounded-pill ms-2">@Model.Count</span>
+            </a>
         </li>
         <li class="nav-item" role="presentation">
-            <a href="@Url.Action("GetAllProjects","Approval", new {  showOnlyUnprocessed = true })" class="nav-link text-dark">
+            <a href="#unprocessed-projects" class="nav-link text-dark @(showOnlyUnprocessed ? "active" : "")" id="unprocessed-projects-tab" data-bs-toggle="tab" data-bs-target="#unprocessed-projects" role="tab" aria-controls="unprocessed-projects" aria-selected="@showOnlyUnprocessed">
                 Unprocessed Projects
+                <span class="badge bg-dark-blue rounded-pill ms-2">@unprocessedProjects.Count</span>
             </a>
         </li>
     </ul>
-    <div class="table-responsive">
-        <table id="projectList" class="table">
-            <caption>List of Projects</caption>
-            <thead>
-            <tr>
-                <th>Project</th>
-                <th>Memberships</th>
-                <th>Decision</th>
-                <th>Status</th>
-                   @* <th>ProjectExpiryDate</th>*@
-                <th>Review</th>
-               
-            </tr>
-            </thead>
-            <tbody>
-            @foreach (var project in Model)
-            {
-                <tr>
-                    <td>
-                        <div class="d-flex align-items-center justify-content-between">
-                            <div>
-                                <a href="@Url.Action("EditProject", new { projectId = project.Id })">
-                                    <h2 class="mb-0 fw-bold hover-underline fs-5">@project.SubmissionProjectName</h2>
-                                </a>
-                                <p class="text-muted font-monospace small mb-0">#@project.SubmissionProjectId</p>
-                                @if (!string.IsNullOrWhiteSpace(project.LocalProjectName))
-                                {
-                                    <p class="mt-2 mb-0">
-                                        Local Name: @project.LocalProjectName
-                                    </p>
-                                }
-                            </div>
-                            @if (project.Archived)
-                            {
-                                <span class="badge py-2 px-3 badge-lg bg-warning text-dark rounded-pill">
-                                    Archived
-                                </span>
-                            }
-                        </div>
-                    </td>
-                    <td>
-                        <a href="@Url.Action("EditMemberships", new { projectId = project.Id })" class="badge py-2 px-3 badge-lg bg-grey text-dark rounded-pill">
-                            @project.MemberDecisions.Count Memberships
-                        </a>
-                    </td>
-                    <td>
 
-                        <p class="my-4">
-                            @project.Decision.ToString()
-                        </p>
-                    </td>
-                    <td>
-                        @if (project.Decision == Decision.Undecided)
-                        {
-                            @:This project hasn't been processed yet
-                        }
-                        else
-                        {
-                            @:Last Updated: @project.LastDecisionDate by @project.ApprovedBy
-                        }
-                    </td>
-                        <td class="text-center">
-                            <a href="@Url.Action("EditProject", new { Projectid = @project.Id })" class="btn btn-sm btn-outline-primary"><span class="small">Review</span></a>
-                        </td>
-                    <td></td>
-                       @* <td>
+    <div class="tab-content" id="projectTabContent">
+        <div class="tab-pane fade @(!showOnlyUnprocessed ? "show active" : "")" id="all-projects" role="tabpanel" aria-labelledby="all-projects-tab">
+            @await Html.PartialAsync("_ProjectsTable", Model)
+        </div>
 
-                            <p class="my-4">
-                                @project.ProjectExpiryDate
-                            </p>
-                        </td>*@
-                    @*<td>
-                            @project.Description
-                        </td>*@
-                    
-                </tr>
-            }
-            </tbody>
-        </table>
-
+        <div class="tab-pane fade @(showOnlyUnprocessed ? "show active" : "")" id="unprocessed-projects" role="tabpanel" aria-labelledby="unprocessed-projects-tab">
+            @await Html.PartialAsync("_ProjectsTable", unprocessedProjects)
+        </div>
     </div>
-
 </div>
+

--- a/src/TRE-UI/Views/Approval/_ProjectsTable.cshtml
+++ b/src/TRE-UI/Views/Approval/_ProjectsTable.cshtml
@@ -1,0 +1,62 @@
+@using BL.Models.Enums
+@model List<BL.Models.TreProject>
+
+<div class="table-responsive">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Project</th>
+                <th>Memberships</th>
+                <th>Decision</th>
+                <th>Status</th>
+                <th>Review</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var project in Model)
+            {
+                <tr>
+                    <td>
+                        <div class="d-flex align-items-center justify-content-between">
+                            <div>
+                                <a href="@Url.Action("EditProject", new { projectId = project.Id })">
+                                    <h2 class="mb-0 fw-bold hover-underline fs-5">@project.SubmissionProjectName</h2>
+                                </a>
+                                <p class="text-muted font-monospace small mb-0">#@project.SubmissionProjectId</p>
+                                @if (!string.IsNullOrWhiteSpace(project.LocalProjectName))
+                                {
+                                    <p class="mt-2 mb-0">Local Name: @project.LocalProjectName</p>
+                                }
+                            </div>
+                            @if (project.Archived)
+                            {
+                                <span class="badge py-2 px-3 badge-lg bg-warning text-dark rounded-pill">Archived</span>
+                            }
+                        </div>
+                    </td>
+                    <td>
+                        <a href="@Url.Action("EditMemberships", new { projectId = project.Id })" class="badge py-2 px-3 badge-lg bg-grey text-dark rounded-pill">
+                            @project.MemberDecisions.Count Memberships
+                        </a>
+                    </td>
+                    <td>
+                        <p class="my-4">@project.Decision.ToString()</p>
+                    </td>
+                    <td>
+                        @if (project.Decision == Decision.Undecided)
+                        {
+                            @:This project hasn't been processed yet
+                        }
+                        else
+                        {
+                            @:Last Updated: @project.LastDecisionDate by @project.ApprovedBy
+                        }
+                    </td>
+                    <td class="text-center">
+                        <a href="@Url.Action("EditProject", new { Projectid = @project.Id })" class="btn btn-sm btn-outline-primary"><span class="small">Review</span></a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/src/TRE-UI/Views/Shared/_Layout.cshtml
+++ b/src/TRE-UI/Views/Shared/_Layout.cshtml
@@ -126,7 +126,7 @@
                         <a class="nav-link text-light" href="https://dareuk.org.uk/contact/" target="_blank" rel="noopener">Contact Us</a>
                     </li>
                 </ul>
-                <p class="text-light mt-md-0 mt-5 mb-0">&copy;DARE UK - @UIName.Name 2023. All rights reserved.</p>
+                <p class="text-light mt-md-0 mt-5 mb-0">&copy;DARE UK - @UIName.Name @DateTime.Now.Year. All rights reserved.</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## :construction: Suggest a change

This PR fix the tab indication on the TRE UI, which didn't change when choosing between `All projects` and `Unprocessed projects`. Also, it fixed the year on the footers of UI apps, making it dynamic.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
