### PR TITLE
fix: validate project end date

### DIFF
--- a/src/DARE-API/Controllers/TESController.cs
+++ b/src/DARE-API/Controllers/TESController.cs
@@ -277,6 +277,11 @@ namespace DARE_API.Controllers
                     return BadRequest("Project " + project + " doesn't exist.");
                 }
 
+                // Reject if current time is past the project's end date
+                if (DateTime.UtcNow > dbproj.EndDate.ToUniversalTime())
+                {
+                    return BadRequest($"Project '{project}' has ended (end date: {dbproj.EndDate:yyyy-MM-dd}). Cannot create new tasks.");
+                }
 
                 if (!IsUserOnProject(dbproj, usersName))
                 {
@@ -624,5 +629,4 @@ namespace DARE_API.Controllers
         }
     }
 }
-
 


### PR DESCRIPTION
## :construction: Suggest a change

This PR added a validation for the project end date: if a task is submitted to an expired project, the submission will fail.

https://ukserp.atlassian.net/browse/TREFX-333

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
