### PR TITLE
feat: Moved back camunda models location fetch from appsettings

### DIFF
--- a/src/Tre-Camunda/appsettings.json
+++ b/src/Tre-Camunda/appsettings.json
@@ -31,9 +31,6 @@
       "RetryTimeoutInMilliseconds": 1000
     }
   },
-  "ProcessModelSettings": {
-    "ModelDirectory": "ProcessModels"
-  },
   "LdapSettings": {
     "Host": "localhost", //ldap.camundaephemeral.local
     "Port": 1389,


### PR DESCRIPTION


## :construction: Suggest a change

A clear and concise description of what you are changing.

Changes done:
- Removed camunda model location from appsettings
- Reverted back code for process deploy in camunda service to previous state so that it fetches directly from ProcessModels within Tre-Camunda
- Tested and deploys to operate correctly

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
