### PR TITLE
ci: fix non main release branch

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -29,7 +29,7 @@ jobs:
   # Job name must be unique across repo to target
   # branch protection rules "required checks" properly!
   containers:
-    uses: SwanseaUniversityMedical/workflows/.github/workflows/pr-and-release-repo.yaml@v2.1.0-repo
+    uses: SwanseaUniversityMedical/workflows/.github/workflows/pr-and-release-repo.yaml@v2.1.2-repo
     with:
       job-name: containers
       release-tag-format: 'v${version}-nottingham-containers'


### PR DESCRIPTION
## :construction: Suggest a change

Fixes releases not triggering from non main branches due to regression in semantic release dependency.
